### PR TITLE
Allow plot overview to redraw overlay correctly when dates set from outside the plot

### DIFF
--- a/jquery.flot.rangeselection.js
+++ b/jquery.flot.rangeselection.js
@@ -309,7 +309,7 @@
                 return;
             }
             var series,data;                
-            if(rangeselection.end === null){
+            if(rangeselection.end === null || o.rangeselection.forceRefreshStartEnd){
                 if(o.rangeselection.end === null){
                     series = plot.getData();
                     data = series[0].data;
@@ -318,7 +318,7 @@
                     rangeselection.end = o.rangeselection.end;
                 }
             }
-            if(rangeselection.start === null){
+            if(rangeselection.start === null || o.rangeselection.forceRefreshStartEnd){
                 if(o.rangeselection.start === null){
                     series = plot.getData();
                     data = series[0].data;
@@ -357,7 +357,8 @@
                start: null,
                enabled: false,
                end: null,
-               callback: null
+               callback: null,
+               forceRefreshStartEnd: false
            }
        },
        name: 'rangeselector',


### PR DESCRIPTION
This commit adds a forceRefreshStartEnd parameter to the plugin options that when enabled will allow the overlay to always use the options start/end dates for redrawing the overlay.

This allows outside code (e.g. a date picker text box) to set the bounds of the overlay and have it redraw correctly.
